### PR TITLE
Async album processing + live admin progress page

### DIFF
--- a/client/src/app/(dashboard)/albums/[album]/processing/page.tsx
+++ b/client/src/app/(dashboard)/albums/[album]/processing/page.tsx
@@ -1,0 +1,222 @@
+"use client"
+
+import { use, useEffect, useRef, useState } from "react"
+import { useRouter } from "next/navigation"
+import Link from "next/link"
+import { motion } from "motion/react"
+import { getUploadStatus, type UploadStatus } from "@/lib/api"
+import { useAuth } from "@/context/auth-context"
+import { Button } from "@/components/ui/button"
+import { Progress } from "@/components/ui/progress"
+import {
+  Check,
+  Loader2,
+  ScanFace,
+  Sparkles,
+  Users,
+  Zap,
+  ImageIcon,
+  AlertCircle,
+  ArrowRight,
+} from "lucide-react"
+
+const PHASES = ["saving", "faces", "clustering", "warming", "done"] as const
+
+type StepDef = {
+  key: (typeof PHASES)[number]
+  label: string
+  hint: string
+  icon: React.ComponentType<{ className?: string }>
+  facesOnly?: boolean
+}
+
+const STEPS: StepDef[] = [
+  { key: "saving", label: "Saving photos", hint: "Uploading to storage", icon: ImageIcon },
+  { key: "faces", label: "Detecting faces", hint: "Finding people in each photo", icon: ScanFace, facesOnly: true },
+  { key: "clustering", label: "Grouping people", hint: "Matching the same person across photos", icon: Users, facesOnly: true },
+  { key: "warming", label: "Optimizing delivery", hint: "Pre-rendering for fast loads", icon: Zap },
+]
+
+export default function ProcessingPage({
+  params,
+}: {
+  params: Promise<{ album: string }>
+}) {
+  const { album: slug } = use(params)
+  const router = useRouter()
+  const { user } = useAuth()
+  const isAdmin = user?.role !== "client"
+
+  const [status, setStatus] = useState<UploadStatus | null>(null)
+  const [failedToLoad, setFailedToLoad] = useState(false)
+  const redirectedRef = useRef(false)
+
+  // clients don't need the progress view — it'll be done by the time they look
+  useEffect(() => {
+    if (user && !isAdmin) router.replace(`/albums/${slug}`)
+  }, [user, isAdmin, slug, router])
+
+  // poll the background job until it finishes
+  useEffect(() => {
+    if (user && !isAdmin) return
+    let active = true
+    let timer: ReturnType<typeof setTimeout>
+
+    const tick = async () => {
+      try {
+        const s = await getUploadStatus(slug)
+        if (!active) return
+        setStatus(s)
+        if (s.finished) return
+      } catch {
+        if (!active) return
+        setFailedToLoad(true)
+      }
+      timer = setTimeout(tick, 1500)
+    }
+    tick()
+
+    return () => {
+      active = false
+      clearTimeout(timer)
+    }
+  }, [slug, user, isAdmin])
+
+  // once done, drift to the album so the admin lands where the work is
+  useEffect(() => {
+    if (status?.finished && !status.error && !redirectedRef.current) {
+      redirectedRef.current = true
+      const t = setTimeout(() => router.replace(`/albums/${slug}`), 2200)
+      return () => clearTimeout(t)
+    }
+  }, [status, slug, router])
+
+  const faces = status?.face_detection ?? true
+  const steps = STEPS.filter((s) => faces || !s.facesOnly)
+  const phaseIdx = status ? PHASES.indexOf(status.phase) : 0
+  const finished = status?.finished ?? false
+  const errored = !!status?.error || failedToLoad
+
+  return (
+    <div className="mx-auto flex min-h-[70dvh] max-w-xl flex-col justify-center px-4 py-10">
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4, ease: [0.23, 1, 0.32, 1] }}
+      >
+        <div className="flex items-center gap-3">
+          <div className="relative flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/15">
+            {finished && !errored ? (
+              <Check className="h-6 w-6 text-primary" />
+            ) : errored ? (
+              <AlertCircle className="h-6 w-6 text-destructive" />
+            ) : (
+              <Sparkles className="h-6 w-6 text-primary" />
+            )}
+          </div>
+          <div>
+            <h1 className="text-xl font-semibold tracking-tight">
+              {errored
+                ? "Processing hit a snag"
+                : finished
+                  ? "All done"
+                  : "Processing your album"}
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              {errored
+                ? "Your photos are saved — some background steps didn’t finish."
+                : finished
+                  ? "Your photos are ready to view."
+                  : "Your photos are saved. The rest runs in the background — you can leave this page."}
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-8 space-y-2">
+          {steps.map((step) => {
+            const idx = PHASES.indexOf(step.key)
+            const state: "done" | "active" | "pending" = finished
+              ? "done"
+              : idx < phaseIdx
+                ? "done"
+                : idx === phaseIdx
+                  ? "active"
+                  : "pending"
+            const showCount =
+              state === "active" &&
+              (step.key === "faces" || step.key === "warming") &&
+              (status?.total ?? 0) > 0
+            const pct = showCount
+              ? Math.round(((status?.current ?? 0) / (status?.total || 1)) * 100)
+              : 0
+
+            return (
+              <div
+                key={step.key}
+                className="flex items-start gap-3 rounded-xl border border-border/70 bg-card p-3.5"
+              >
+                <div
+                  className={`mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg ${
+                    state === "done"
+                      ? "bg-primary/15 text-primary"
+                      : state === "active"
+                        ? "bg-primary/15 text-primary"
+                        : "bg-muted text-muted-foreground"
+                  }`}
+                >
+                  {state === "done" ? (
+                    <motion.span
+                      initial={{ scale: 0.6, opacity: 0 }}
+                      animate={{ scale: 1, opacity: 1 }}
+                      transition={{ duration: 0.25, ease: [0.23, 1, 0.32, 1] }}
+                    >
+                      <Check className="h-4 w-4" />
+                    </motion.span>
+                  ) : state === "active" ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <step.icon className="h-4 w-4" />
+                  )}
+                </div>
+
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center justify-between gap-2">
+                    <p
+                      className={`text-sm font-medium ${
+                        state === "pending" ? "text-muted-foreground" : ""
+                      }`}
+                    >
+                      {step.label}
+                    </p>
+                    {showCount && (
+                      <span className="font-mono text-xs text-muted-foreground tabular-nums">
+                        {status?.current}/{status?.total}
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-xs text-muted-foreground">{step.hint}</p>
+                  {showCount && <Progress value={pct} className="mt-2 h-1" />}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+
+        <div className="mt-8 flex items-center gap-3">
+          <Button
+            render={<Link href={`/albums/${slug}`} />}
+            variant={finished && !errored ? "default" : "outline"}
+          >
+            {finished ? "View album" : "Go to album"}
+            <ArrowRight className="h-4 w-4" />
+          </Button>
+          {!finished && !errored && (
+            <span className="text-xs text-muted-foreground">
+              Safe to leave — this keeps running.
+            </span>
+          )}
+        </div>
+      </motion.div>
+    </div>
+  )
+}

--- a/client/src/components/upload-album-dialog.tsx
+++ b/client/src/components/upload-album-dialog.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useRef, useCallback } from "react"
+import { useRouter } from "next/navigation"
 import { uploadAlbum, type UploadStage } from "@/lib/api"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -39,6 +40,7 @@ const STAGE_LABEL: Record<UploadStage["stage"], string> = {
   uploading: "Uploading photos",
   saving: "Saving",
   faces: "Detecting faces",
+  clustering: "Grouping people",
   warming: "Optimizing images",
   done: "Finishing up",
 }
@@ -68,6 +70,7 @@ export function UploadAlbumDialog({
   initialFiles,
   lockFaceDetection = false,
 }: Props) {
+  const router = useRouter()
   const [internalOpen, setInternalOpen] = useState(false)
   const open = controlledOpen ?? internalOpen
   const [name, setName] = useState("")
@@ -118,7 +121,7 @@ export function UploadAlbumDialog({
     setUploading(true)
     setStage({ stage: "uploading", pct: 0 })
     try {
-      await uploadAlbum(
+      const { albumSlug, processing } = await uploadAlbum(
         { files, albumName: resolvedName, userId, faceDetection: faces },
         setStage
       )
@@ -129,6 +132,10 @@ export function UploadAlbumDialog({
       )
       onUploaded()
       setOpen(false)
+      // faces/warming run server-side now — hand off to the live progress page
+      if (processing && albumSlug) {
+        router.push(`/albums/${albumSlug}/processing`)
+      }
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Upload failed")
       setUploading(false)

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -87,10 +87,32 @@ export type UploadOptions = {
 }
 
 export type UploadStage = {
-  stage: "uploading" | "saving" | "faces" | "warming" | "done"
+  stage: "uploading" | "saving" | "faces" | "clustering" | "warming" | "done"
   pct?: number // for "uploading" (network)
   current?: number // for server stages
   total?: number
+}
+
+export type UploadResult = {
+  albumSlug: string
+  processing: boolean
+}
+
+export type UploadStatus = {
+  album_slug: string
+  active: boolean
+  finished: boolean
+  phase: "saving" | "faces" | "clustering" | "warming" | "done"
+  current: number
+  total: number
+  error: string | null
+  face_detection: boolean
+  image_count?: number
+}
+
+/** Poll background album processing (faces, clustering, cdn warming). */
+export function getUploadStatus(slug: string): Promise<UploadStatus> {
+  return apiFetch<UploadStatus>(`/upload-status/${slug}`)
 }
 
 /**
@@ -104,7 +126,7 @@ export type UploadStage = {
 export function uploadAlbum(
   opts: UploadOptions,
   onStage?: (s: UploadStage) => void
-): Promise<void> {
+): Promise<UploadResult> {
   return new Promise((resolve, reject) => {
     const token = getToken()
     const wsUrl = API_URL.replace(/^http/, "ws") + "/ws/"
@@ -112,13 +134,13 @@ export function uploadAlbum(
     let settled = false
     let started = false
 
-    const finish = (err?: Error) => {
+    const finish = (err?: Error, result?: UploadResult) => {
       if (settled) return
       settled = true
       try {
         ws.close()
       } catch {}
-      err ? reject(err) : resolve()
+      err ? reject(err) : resolve(result ?? { albumSlug: "", processing: false })
     }
 
     ws.onmessage = (e) => {
@@ -156,7 +178,17 @@ export function uploadAlbum(
       }
       xhr.onload = () => {
         if (xhr.status >= 200 && xhr.status < 300) {
-          finish()
+          // server returns once files are saved; faces/warming run in the
+          // background and are tracked on the processing page.
+          let result: UploadResult = { albumSlug: "", processing: false }
+          try {
+            const body = JSON.parse(xhr.responseText)
+            result = {
+              albumSlug: body.album_slug ?? "",
+              processing: !!body.processing,
+            }
+          } catch {}
+          finish(undefined, result)
         } else {
           let msg = "Upload failed"
           try {

--- a/server/routers/files/files_router.py
+++ b/server/routers/files/files_router.py
@@ -22,6 +22,7 @@ from utils.utils import get_file_metadata, add_album_to_user
 from utils.image_utils import generate_blur_data_url
 from services.cdn_warm import warm_key
 from routers.websocket.websocket_router import manager
+from services import upload_jobs
 from dependencies import oauth2_scheme, get_current_user, require_admin
 from services.gemini_service import analyze_image
 from fastapi.responses import StreamingResponse
@@ -199,7 +200,8 @@ async def create_upload_files(
     face_targets = []
     keys = []  # image keys to warm (videos aren't transformed/warmed)
 
-    # stage 1: save each file to S3 + (for images) record metadata + blur
+    # stage 1: save each file to S3 + (for images) record metadata + blur.
+    # This is the only work that needs the request body, so it stays inline.
     for i, file in enumerate(files):
         content = await file.read()
         ctype = file.content_type or _guess_content_type(file.filename)
@@ -214,46 +216,103 @@ async def create_upload_files(
         session.query(FileMetadata).filter_by(album_id=album.id).count()
     )
     session.commit()
+    image_count = album.image_count
 
-    # stage 2: detect + index faces (off the event loop so progress can flush)
-    if face_targets:
-        n = len(face_targets)
-        for i, (s3_key, meta_id) in enumerate(face_targets):
-            # one bad photo (no detectable face, odd crop, etc.) must never
-            # 500 the whole upload — log and keep going
+    # faces + clustering + cdn warming can run for minutes on a big album —
+    # well past any proxy timeout. Hand them to a background task and return
+    # now so the admin gets routed to a live progress page instead of a 504.
+    processing = bool(face_targets or keys)
+    if processing:
+        upload_jobs.start_job(
+            album_slug, face_detection=bool(face_targets), image_count=image_count
+        )
+        asyncio.create_task(
+            _process_album(
+                album.id, album_slug, face_targets, keys, update, image_count
+            )
+        )
+    else:
+        await _notify("done", total, total)
+
+    return {
+        "filenames": [file.filename for file in files],
+        "album_slug": album_slug,
+        "processing": processing,
+    }
+
+
+async def _process_album(album_id, album_slug, face_targets, keys, update, image_count):
+    """Background: detect faces, regroup, warm the CDN. Updates the job
+    registry (polled by the processing page) and the websocket as it goes."""
+    try:
+        # stage 2: detect + index faces (off the event loop so progress flushes)
+        if face_targets:
+            n = len(face_targets)
+            upload_jobs.update_job(album_slug, phase="faces", current=0, total=n)
+            await _notify("faces", 0, n)
+            for i, (s3_key, meta_id) in enumerate(face_targets):
+                # one bad photo must never abort the whole album — log & continue
+                try:
+                    await asyncio.to_thread(
+                        detect_and_store_faces, s3_key, meta_id, album_id, AWS_BUCKET
+                    )
+                except Exception as e:
+                    print(f"face detection failed for {s3_key}: {e}")
+                upload_jobs.update_job(album_slug, phase="faces", current=i + 1, total=n)
+                await _notify("faces", i + 1, n)
+
+            # authoritative regroup (Chinese Whispers); never fatal — detect
+            # already wrote consistent links, recluster only refines them.
+            upload_jobs.update_job(album_slug, phase="clustering")
+            await _notify("clustering", 0, 0)
             try:
-                await asyncio.to_thread(
-                    detect_and_store_faces, s3_key, meta_id, album.id, AWS_BUCKET
-                )
+                await asyncio.to_thread(recluster_faces)
             except Exception as e:
-                print(f"face detection failed for {s3_key}: {e}")
-            await _notify("faces", i + 1, n)
-        # authoritative regroup (Chinese Whispers) so a new upload can't leave
-        # people mis-merged; cheap on reruns (stable ids + chips reused).
-        # never let a clustering hiccup fail the upload — detect already wrote
-        # consistent links, recluster only refines them.
-        try:
-            await asyncio.to_thread(recluster_faces)
-        except Exception as e:
-            print(f"recluster after upload failed (non-fatal): {e}")
+                print(f"recluster after upload failed (non-fatal): {e}")
 
-    # stage 3: pre-warm CDN derivatives so the first view isn't a cold SIH render
-    done = 0
-    tasks = [asyncio.create_task(asyncio.to_thread(warm_key, k)) for k in keys]
-    await _notify("warming", 0, total)
-    for task in asyncio.as_completed(tasks):
-        await task
-        done += 1
-        await _notify("warming", done, total)
+        # stage 3: pre-warm CDN derivatives so the first view isn't a cold render
+        warm_total = len(keys)
+        done = 0
+        upload_jobs.update_job(album_slug, phase="warming", current=0, total=warm_total)
+        await _notify("warming", 0, warm_total)
+        tasks = [asyncio.create_task(asyncio.to_thread(warm_key, k)) for k in keys]
+        for task in asyncio.as_completed(tasks):
+            await task
+            done += 1
+            upload_jobs.update_job(
+                album_slug, phase="warming", current=done, total=warm_total
+            )
+            await _notify("warming", done, warm_total)
 
-    # re-uploading into an existing album can overwrite photos at the same key;
-    # purge the CDN so it stops serving the old cached image
-    if update:
-        await asyncio.to_thread(invalidate_cdn)
+        # re-uploading can overwrite photos at the same key; purge stale CDN copies
+        if update:
+            await asyncio.to_thread(invalidate_cdn)
 
-    await _notify("done", total, total)
+        upload_jobs.finish_job(album_slug)
+        await _notify("done", image_count, image_count)
+    except Exception as e:
+        print(f"album processing failed for {album_slug}: {e}")
+        upload_jobs.fail_job(album_slug, str(e))
+        await _notify("error", 0, 0)
 
-    return {"filenames": [file.filename for file in files]}
+
+@router.get("/api/upload-status/{album_slug}")
+async def upload_status(album_slug: str, current_user=Depends(require_admin)):
+    """Live status for the admin processing page. Returns finished=True when
+    there's no active job (already done, or the page was opened late)."""
+    job = upload_jobs.get_job(album_slug)
+    if not job:
+        return {
+            "album_slug": album_slug,
+            "active": False,
+            "finished": True,
+            "phase": "done",
+            "current": 0,
+            "total": 0,
+            "error": None,
+            "face_detection": False,
+        }
+    return {"album_slug": album_slug, "active": not job["finished"], **job}
 
 
 @router.post("/api/upload-zip/")

--- a/server/services/upload_jobs.py
+++ b/server/services/upload_jobs.py
@@ -1,0 +1,55 @@
+"""In-memory registry for background album-processing jobs.
+
+After files are saved in-request, face detection / clustering / CDN warming
+run as a background task. The admin's processing page polls
+GET /api/upload-status/{slug} which reads from here. Single-replica deploy,
+so an in-process dict is sufficient and avoids a schema migration.
+"""
+
+import time
+
+# album_slug -> job dict
+_jobs: dict[str, dict] = {}
+
+# phase order the UI renders as a stepper
+PHASES = ["saving", "faces", "clustering", "warming", "done"]
+
+
+def start_job(slug: str, *, face_detection: bool, image_count: int) -> None:
+    _jobs[slug] = {
+        "phase": "faces" if face_detection else "warming",
+        "current": 0,
+        "total": 0,
+        "error": None,
+        "finished": False,
+        "face_detection": face_detection,
+        "image_count": image_count,
+        "started_at": time.time(),
+        "updated_at": time.time(),
+    }
+
+
+def update_job(slug: str, *, phase: str, current: int = 0, total: int = 0) -> None:
+    job = _jobs.get(slug)
+    if not job:
+        return
+    job.update(phase=phase, current=current, total=total, updated_at=time.time())
+
+
+def finish_job(slug: str) -> None:
+    job = _jobs.get(slug)
+    if not job:
+        return
+    job.update(phase="done", finished=True, updated_at=time.time())
+
+
+def fail_job(slug: str, error: str) -> None:
+    job = _jobs.get(slug)
+    if not job:
+        return
+    job.update(error=error, finished=True, updated_at=time.time())
+
+
+def get_job(slug: str) -> dict | None:
+    job = _jobs.get(slug)
+    return dict(job) if job else None


### PR DESCRIPTION
## Why
Uploading a big album with face detection ran the **entire** pipeline (face detection on every photo + clustering + CDN warming) *inside* the `POST /api/upload-files/` request. On large albums that runs for minutes, blows past the proxy read timeout, and the browser gets a **504** even though the backend is happily working. (Hit this on the Paramakusum Srinivasa Kalyanam album.)

## What changed
The request now only does the part that needs the request body — saving each file to S3 + recording metadata + blur — then **returns immediately** and runs the slow stuff in the background.

**Backend**
- `services/upload_jobs.py` — small in-memory job registry (phase / current / total / error). No DB migration: single replica, and the status is transient.
- `upload-files` saves files, then spawns `_process_album()` (faces → clustering → CDN warming → invalidate) as a background task; returns `{ filenames, album_slug, processing }`.
- New `GET /api/upload-status/{album_slug}` (admin-only) that the progress page polls.

**Client**
- `uploadAlbum()` now resolves as soon as files are saved and returns `{ albumSlug, processing }`.
- On success the upload dialog routes the admin to **`/albums/[slug]/processing`** — a stepper that polls status and shows **Saving → Detecting faces → Grouping people → Optimizing delivery** with live counts, then drifts to the album when done.
- Admin-only: clients are redirected straight to the gallery (it's finished by the time they look).

## Verified
- `bun run build` clean (type-safe); new `/albums/[album]/processing` route registered.
- Backend compiles; processing route renders behind the admin auth gate (no SSR crash).
- **Not deployed yet** — end-to-end (real upload → faces complete) needs a deploy, and I intentionally didn't redeploy while the live wedding album was still processing. Merge/deploy when that's done.

## Companion infra fix (already applied, separate from this PR)
Raised NPM's `proxy_read_timeout`/`proxy_send_timeout` to 3600s for `aura-api.reactiveshots.com` (the k3s ingress already allowed 3600s; NPM was defaulting to 60s) so even the in-request save phase can't 504.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* New processing page displays real-time album upload and processing progress with live status updates.
* Upload workflow now includes clustering and warming processing stages tracked with progress indicators.
* Background processing enables the application to continue functioning while albums are being processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->